### PR TITLE
Fixed missed timer unsetting

### DIFF
--- a/src/SendSlinStream.php
+++ b/src/SendSlinStream.php
@@ -117,6 +117,7 @@ final class SendSlinStream extends EventEmitter implements WritableStreamInterfa
         }
 
         Loop::cancelTimer($this->timer);
+        $this->timer = null;
     }
 
     private function onTimer(): void


### PR DESCRIPTION
In the `SendSlinStream` class was missed unsetting of the `SendSlinStream::$stream` property value after it being detached.